### PR TITLE
Remove cmake-version/conan-version overrides now provided by the reusable workflow

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -58,8 +58,6 @@ jobs:
 
       - name: install conan
         uses: dice-group/cpp-conan-release-reusable-workflow/.github/actions/configure_conan@v2.1.0
-        with:
-          conan-version: 2.31.2
 
       - name: add conan user
         run: |

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -57,9 +57,7 @@ jobs:
       - uses: rui314/setup-mold@v1
 
       - name: install conan
-        uses: dice-group/cpp-conan-release-reusable-workflow/.github/actions/configure_conan@v2.1.0
-        with:
-          conan-version: 2.31.2
+        uses: dice-group/cpp-conan-release-reusable-workflow/.github/actions/configure_conan@v2.1.1
 
       - name: add conan user
         run: |
@@ -92,7 +90,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Get dependency provider
-        uses: dice-group/cpp-conan-release-reusable-workflow/.github/actions/add_conan_provider@v2.1.0
+        uses: dice-group/cpp-conan-release-reusable-workflow/.github/actions/add_conan_provider@v2.1.1
 
       - name: Configure CMake
         id: configure-cmake

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -58,6 +58,8 @@ jobs:
 
       - name: install conan
         uses: dice-group/cpp-conan-release-reusable-workflow/.github/actions/configure_conan@v2.1.0
+        with:
+          conan-version: 2.31.2
 
       - name: add conan user
         run: |

--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -13,8 +13,6 @@ jobs:
       public_artifactory: true
       os: ubuntu-24.04
       compiler: clang-19
-      cmake-version: 4.4.2
-      conan-version: 2.31.2
       conan-options: -o boost/*:header_only=True
     secrets:
       CONAN_CICD_USERNAME: ${{ secrets.CONAN_CICD_USERNAME }}

--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -13,6 +13,7 @@ jobs:
       public_artifactory: true
       os: ubuntu-24.04
       compiler: clang-19
+      conan-version: 2.31.2
       conan-options: -o boost/*:header_only=True
     secrets:
       CONAN_CICD_USERNAME: ${{ secrets.CONAN_CICD_USERNAME }}

--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -8,12 +8,11 @@ concurrency:
 
 jobs:
   publish-conan-branch-package:
-    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-conan-branch-package.yml@v2.1.0
+    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-conan-branch-package.yml@v2.1.1
     with:
       public_artifactory: true
       os: ubuntu-24.04
       compiler: clang-19
-      conan-version: 2.31.2
       conan-options: -o boost/*:header_only=True
     secrets:
       CONAN_CICD_USERNAME: ${{ secrets.CONAN_CICD_USERNAME }}


### PR DESCRIPTION
Bumps the `dice-group/cpp-conan-release-reusable-workflow` pin to `v2.1.1` and removes the `cmake-version`/`conan-version` overrides that just duplicated its defaults.

`v2.1.1` fixes the two gaps that made this unsafe before: `cmake-version` default is now `4.4.2` (matching the `lukka/get-cmake@v4.4.2` pin), and `configure_conan`'s own `conan-version` default is now `2.31.2` (previously a stale `2.3.1` that broke `clang-19`+ builds -- confirmed by CI failure on an earlier version of this PR). Both overrides now exactly duplicate what the reusable workflow already provides.

Not merged -- ready for review.